### PR TITLE
Feature(rxjs/catchErrorSource): continue emitting after first error

### DIFF
--- a/libs/rxjs/src/lib/sources/catch-error-source.operator.spec.ts
+++ b/libs/rxjs/src/lib/sources/catch-error-source.operator.spec.ts
@@ -1,0 +1,59 @@
+import { catchErrorSource } from "@state-adapt/rxjs";
+import { TestScheduler } from "rxjs/testing";
+import { getAction } from "@state-adapt/core";
+import { map } from "rxjs/operators";
+
+const observableMatcher = (actual: any, expected: any) => expect(actual).toEqual(expected)
+
+const typePrefix = 'obs';
+const type = `${typePrefix}.error$`;
+const catchErrorSourceOp = catchErrorSource(typePrefix);
+
+describe('catchErrorSource()', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should pass regular values as is', () => {
+    testScheduler.run(({hot, expectObservable}) => {
+      const values = {
+        a: 1,
+        b: 2,
+        c: 3,
+      };
+      const source = hot('-ab-(c|)', values).pipe(catchErrorSourceOp);
+      const result = '-ab-(c|)';
+      expectObservable(source).toBe(result, values);
+    });
+  });
+
+  it('should catch errors and transform them into actions', () => {
+    testScheduler.run(({hot, expectObservable}) => {
+      const values = {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+        x: 101,
+        y: 102,
+      };
+      const throwIfGraterThan100 = (value: number) => {
+        if (value > 100) {
+          throw (`e${value - 100}`);
+        } else {
+          return value;
+        }
+      }
+      const source = hot('abxcyd', values).pipe(map(throwIfGraterThan100), catchErrorSourceOp);
+      const result = 'abxcyd';
+      const resultValues = {
+        ...values,
+        x: getAction(type, 'e1'),
+        y: getAction(type, 'e2'),
+      };
+      expectObservable(source).toBe(result, resultValues);
+    });
+  });
+});

--- a/libs/rxjs/src/lib/sources/catch-error-source.operator.ts
+++ b/libs/rxjs/src/lib/sources/catch-error-source.operator.ts
@@ -1,4 +1,4 @@
-import { Observable, of } from 'rxjs';
+import { concat, Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { Action, getAction } from '@state-adapt/core';
 
@@ -31,5 +31,5 @@ export function catchErrorSource<Payload, TypePrefix extends string>(
   return (
     source$: Observable<Payload>,
   ): Observable<Payload | Action<any, `${TypePrefix}.error$`>> =>
-    source$.pipe(catchError(err => of(getAction(`${typePrefix}.error$`, err))));
+    source$.pipe(catchError((err, caught) => concat(of(getAction(`${typePrefix}.error$`, err)), caught)));
 }


### PR DESCRIPTION
catchErrorSource now translates an error to an action and continues with the original observable, the observable the operator operates on should be a hot observable, otherwise the whole caught observable will be replayed on error

fixes #54