### PR TITLE
Add ng add Schematic for Angular Projects (#66)

### DIFF
--- a/libs/angular/package.json
+++ b/libs/angular/package.json
@@ -7,5 +7,6 @@
   },
   "dependencies": {
     "tslib": "^2.3.0"
-  }
+  },
+  "schematics": "./schematics/collection.json"
 }

--- a/libs/angular/src/lib/schematics/collection.json
+++ b/libs/angular/src/lib/schematics/collection.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "aliases": [],
+      "factory": "./ng-add",
+      "schema": "./ng-add/schema.json",
+      "description": "Add StateAdapt to your application"
+    }
+  }
+}

--- a/libs/angular/src/lib/schematics/ng-add/index.spec.ts
+++ b/libs/angular/src/lib/schematics/ng-add/index.spec.ts
@@ -1,0 +1,66 @@
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+
+import { Schema } from './schema';
+
+export const defaultAppOptions = {
+  name: 'bar',
+  inlineStyle: false,
+  inlineTemplate: false,
+  viewEncapsulation: 'Emulated',
+  routing: false,
+  style: 'css',
+  skipTests: false,
+};
+
+const defaultSchematicOptions: Schema = {
+  skipInstall: false,
+};
+
+export const defaultWorkspaceOptions: Schema = {
+  name: 'workspace',
+  newProjectRoot: 'projects',
+  version: '0.0.0',
+};
+
+describe('StateAdapt ng-add Schematic', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@state-adapt/angular',
+    path.join(__dirname, '../collection.json'),
+  );
+
+  let appTree: UnitTestTree;
+
+  beforeEach(async () => {
+    appTree = await schematicRunner
+      .runExternalSchematicAsync(
+        '@schematics/angular',
+        'workspace',
+        defaultWorkspaceOptions,
+      )
+      .toPromise();
+
+    appTree = await schematicRunner
+      .runExternalSchematicAsync(
+        '@schematics/angular',
+        'application',
+        defaultAppOptions,
+        appTree,
+      )
+      .toPromise();
+  });
+
+  it('should update package.json', async () => {
+    const options = { ...defaultSchematicOptions };
+
+    const tree = await schematicRunner
+      .runSchematicAsync('ng-add', options, appTree)
+      .toPromise();
+
+    const packageJson = JSON.parse(tree.readContent('/package.json'));
+
+    expect(packageJson.dependencies['@state-adapt/core']).toBeDefined();
+    expect(packageJson.dependencies['@state-adapt/rxjs']).toBeDefined();
+    expect(packageJson.dependencies['@state-adapt/angular']).toBeDefined();
+  });
+});

--- a/libs/angular/src/lib/schematics/ng-add/index.ts
+++ b/libs/angular/src/lib/schematics/ng-add/index.ts
@@ -1,0 +1,79 @@
+import { Rule, SchematicContext, Tree, chain } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+
+import { Schema } from './schema';
+
+const version = '^2.0.0';
+const corePackages = ['@state-adapt/core', '@state-adapt/rxjs', '@state-adapt/angular'];
+
+/** Represents an entry in the package.json */
+type PackageJsonEntry = {
+  type: 'dependencies' | 'devDependencies' | 'peerDependencies';
+  pkg: string;
+  version: string;
+};
+
+/**
+ * Add a set of packages to the package.json
+ * @param host The current workspace's host
+ * @param entries A collection of {@link PackageJsonEntry} to add
+ * @returns The resulting workspace's {@link Tree}
+ */
+function addPackageToPackageJson(host: Tree, entries: PackageJsonEntry[]): Tree {
+  if (!host.exists('package.json')) {
+    console.error('Unable to locate package.json');
+    return host;
+  }
+
+  const packageJsonContent = host.read('package.json')?.toString('utf-8') ?? '{}';
+  const json = JSON.parse(packageJsonContent);
+
+  entries.forEach(({ type, pkg, version }: PackageJsonEntry) => {
+    if (!json[type]) {
+      json[type] = {};
+    }
+
+    if (!json[type][pkg]) {
+      json[type][pkg] = version;
+    }
+  });
+
+  host.overwrite('package.json', JSON.stringify(json, null, 2));
+
+  return host;
+}
+
+/**
+ * Add StateAdapt Angular's packages to the package.json
+ * @returns The rule to be executed to add the StateAdapt's dependencies
+ */
+function addPackagesToPackageJson(options: Schema): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    const packages = corePackages.map(
+      (pkg: string): PackageJsonEntry => ({
+        type: 'dependencies',
+        pkg,
+        version,
+      }),
+    );
+
+    addPackageToPackageJson(host, packages);
+
+    if (!options.skipInstall) {
+      context.addTask(new NodePackageInstallTask());
+    }
+
+    return host;
+  };
+}
+
+/**
+ * Entrypoint for the `ng add` schematic
+ * @param options Additional configuration and flags for the schematic
+ * @returns The rule to be executed to add the StateAdapt's dependencies
+ */
+export default function (options: Schema): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    return chain([addPackagesToPackageJson(options)])(host, context);
+  };
+}

--- a/libs/angular/src/lib/schematics/ng-add/schema.json
+++ b/libs/angular/src/lib/schematics/ng-add/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "StateAdaptAngular",
+  "title": "StateAdapt Angular Schema",
+  "type": "object",
+  "properties": {
+    "skipInstall": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not install dependency packages."
+    }
+  },
+  "required": []
+}

--- a/libs/angular/src/lib/schematics/ng-add/schema.ts
+++ b/libs/angular/src/lib/schematics/ng-add/schema.ts
@@ -1,0 +1,3 @@
+export interface Schema {
+  skipInstall?: boolean;
+}

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "14.0.3",
+    "@angular-devkit/schematics": "14.0.3",
     "@angular-eslint/eslint-plugin": "13.2.1",
     "@angular-eslint/eslint-plugin-template": "13.2.1",
     "@angular-eslint/template-parser": "13.2.1",


### PR DESCRIPTION
Hi!

I've been using StateAdapt a lot lately and I wanted to help a bit.

Regarding #66, I attempted to add a schematic for supporting `ng add` for Angular projects.
As this is the standard way of incorporating a library into an Angular project, it might encourage adoption among Angular developers.

This schematic aims to add the necessary imports (`@state-adapt/core`, `@state-adapt/rxjs` and `@state-adapt/angular`) to an Angular project and install them. Additionally, the installation step can be skipped if specified.

> This is my first attempt at writing an `ng add` schematic. I followed the various resources found on the web and on other libraries such as NgRx (especially [the component-store module](https://github.com/ngrx/platform/tree/main/modules/component-store/schematics)) as well as adding tests, but I would greatly appreciate a review to identify and address any potential issues.

I hope that this can be of any help and would gladly make any correction I need to.