### PR TITLE
[Docs] Add ng add schematic doc

### DIFF
--- a/apps/docs/src/app/get-started/get-started-angular.md
+++ b/apps/docs/src/app/get-started/get-started-angular.md
@@ -22,7 +22,13 @@
 
 [StackBlitz Demo](https://stackblitz.com/edit/state-adapt-angular?file=src%2Fapp%2Fapp.module.ts)
 
-First, `npm install`:
+First, add StateAdapt to your project using `ng add`:
+
+```sh
+ng add @state-adapt/angular
+```
+
+Alternatively, you can install the dependencies using a package manager:
 
 ```sh
 npm i -s @state-adapt/{core,rxjs,angular}

--- a/apps/docs/src/app/get-started/get-started-angular.md
+++ b/apps/docs/src/app/get-started/get-started-angular.md
@@ -24,7 +24,7 @@
 
 First, `npm install`:
 
-```
+```sh
 npm i -s @state-adapt/{core,rxjs,angular}
 ```
 
@@ -54,7 +54,7 @@ Go to [Tutorials](angular/get-started#tutorials) for help on how to use StateAda
 
 First, `npm install`:
 
-```
+```sh
 npm i -s @state-adapt/{core,rxjs,angular,ngrx}
 ```
 
@@ -91,7 +91,7 @@ Go to [Tutorials](angular/get-started#tutorials) for help on how to use StateAda
 
 First, `npm install`:
 
-```
+```sh
 npm i -s @state-adapt/{core,rxjs,angular,ngxs}
 ```
 


### PR DESCRIPTION
Follow-up of the discussion #66 and the addition of the schematic in #78

This PR adds an alternative to the installation step in Angular by leveraging the `ng add` schematic