### PR TITLE
Enhanced `toSource` operator to avoid nested `Action` observables and just rename their `Type` string in such cases

### DIFF
--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -10,6 +10,7 @@ export * from './lib/actions/action.interface';
 export * from './lib/actions/prefixed-action.type';
 export * from './lib/actions/prefix-action.function';
 export * from './lib/actions/get-action.function';
+export * from './lib/actions/is-action.function';
 
 export * from './lib/selectors/selectors.interface';
 export * from './lib/selectors/any-selectors.interface';

--- a/libs/core/src/lib/actions/is-action.function.ts
+++ b/libs/core/src/lib/actions/is-action.function.ts
@@ -1,0 +1,6 @@
+import { Action } from './action.interface';
+
+export function isAction(thing: unknown): thing is Action<any> {
+  return typeof thing === 'object' && thing != null
+    && 'type' in thing && 'payload' in thing;
+}

--- a/libs/rxjs/src/lib/sources/to-source.operator.ts
+++ b/libs/rxjs/src/lib/sources/to-source.operator.ts
@@ -1,6 +1,8 @@
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { Action } from '@state-adapt/core';
+import { Action, isAction } from '@state-adapt/core';
+
+type UnAction<T> = T extends Action<infer P> ? P : T;
 
 /**
   ## ![StateAdapt](https://miro.medium.com/max/4800/1*qgM6mFM2Qj6woo5YxDMSrA.webp|width=14) `toSource`
@@ -25,6 +27,12 @@ import { Action } from '@state-adapt/core';
   ```
  */
 export function toSource<Payload, Type extends string>(type: Type) {
-  return (source$: Observable<Payload>): Observable<Action<Payload, Type>> =>
-    source$.pipe(map(payload => ({ type, payload })));
+  return (source$: Observable<Payload>): Observable<Action<UnAction<Payload>, Type>> =>
+    source$.pipe(map(payload => {
+      if (isAction(payload)) {
+        return { type, payload: payload.payload };
+      }
+
+      return { type, payload };
+    }));
 }


### PR DESCRIPTION
### Summary

Improved the `toSource()` operator to flatten `Action` observables, enabling direct renaming of the `Type` and ensuring compatibility with the `adapt()` function.

### Problem

Previously, using `toSource` on an `Action` observable created a nested structure (`Observable<Action<Action<T, OldType>, NewType>>`), which `adapt()` couldn't process effectively as a `Source`.

### Motivation

This update addresses the incompatibility with `adapt()` and simplifies the developer's workflow by allowing one to straightforwardly rename a `Source` at the end of a pipeline when that sometimes makes sense.

### Solution

The `toSource` operator now detects `Action` observables, flattening any nested actions and directly renaming the `Type`, avoiding the nested `Action<Action<T, OldType>, NewType>>` structure.

### Changes Made

- Implemented detection and flattening of nested `Action` observables.